### PR TITLE
Fix checkRetiredsApproved for changing admin list

### DIFF
--- a/contracts/TreasuryRebalance.sol
+++ b/contracts/TreasuryRebalance.sol
@@ -254,13 +254,14 @@ contract TreasuryRebalance is Ownable, ITreasuryRebalance {
                 );
                 //if min quorom reached, make sure all approvers are still valid
                 address[] memory approvers = retired.approvers;
-                uint256 minApprovals = 0;
+                uint256 validApprovals = 0;
                 for (uint256 j = 0; j < approvers.length; j++) {
-                    _validateAdmin(approvers[j], adminList);
-                    minApprovals++;
+                    if (_validateAdmin(approvers[j], adminList)) {
+                        validApprovals++;
+                    }
                 }
                 require(
-                    minApprovals >= req,
+                    validApprovals >= req,
                     "min required admins should approve"
                 );
             } else {


### PR DESCRIPTION
- Bug fix: boolean return value of `_validateAdmin` was ignored
- Increase test coverage of TreasuryRebalance.sol to:
  Statements 90/90 Branches 90/92 Functions 28/28 Lines 115/115